### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Burritos",
     platforms: [
     .macOS(.v10_10),
-            .iOS(.v8),
+            .iOS(.v9),
             .tvOS(.v9),
             .watchOS(.v2)
     ],


### PR DESCRIPTION
Bumped minimum iOS deployment version from 8 to 9 in order to comply with Xcode 12's minimum deployment range. Fixes compiler warning when installing via SPM.